### PR TITLE
RFC: clicking a type or term opens it in scrach.u

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -26,6 +26,7 @@ const TermObject = t.type(
 	},
 	"TermObject"
 );
+export type TTermObject = t.TypeOf<typeof TermObject>;
 
 const TypeObject = t.type(
 	{
@@ -38,6 +39,7 @@ const TypeObject = t.type(
 	},
 	"TypeObject"
 );
+export type TTypeObject = t.TypeOf<typeof TypeObject>;
 
 const PatchObject = t.type(
 	{

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+import { ApiClient } from "./api";
+import { definitionSource, mapDefinitionsByName } from "./definition";
+
+// BUG: if a definition exists in the file already, we should not insert it again.
+// BUG: when inserting at the beginning of a file whitespace formats nicely, but when inserting inside a file it does not.
+// CONSIDERATION: should the definition be shared when it's loaded from the sidebar? i was worried about dealing with stale data.
+export const edit = (apiClient: ApiClient) => async  (names: string) => {
+    const fsPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+    if (!fsPath) {
+        throw new Error("Could not find VSCode workspace");
+    }
+
+    // build the source
+    const definition = await apiClient.getDefinition({ names });
+    const mapDefinitions = mapDefinitionsByName(names);
+    const termDefinitions = mapDefinitions(definition.termDefinitions);
+    const typeDefinitions = mapDefinitions(definition.typeDefinitions);
+    const source = definitionSource(
+        termDefinitions[names]?.termDefinition ||
+        typeDefinitions[names]?.typeDefinition
+    );
+
+    if (!source) {
+        throw new Error(`Could not find definitions for ${names}`);
+    }
+
+    // create scratch.u and focus it
+    const uri = vscode.Uri.file([fsPath, "scratch.u"].join("/"));
+    const edit = new vscode.WorkspaceEdit();
+    edit.createFile(uri, { ignoreIfExists: true });
+    await vscode.workspace.applyEdit(edit);
+    await vscode.window.showTextDocument(uri, { preview: false });
+    
+    // prepend source to scratch.u at current selection, and reset current selection.
+    // this enables both the "prepend to top" default, as well as "insert how you want".
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+        const position = editor.selection.active;
+        editor.edit((text) => text.replace(position, `${source}\n\n`));
+        editor.selections = [new vscode.Selection(position, position)];
+    }
+};

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,0 +1,12 @@
+import * as ReadonlyRecord from "fp-ts/ReadonlyRecord";
+import * as ReadonlyArray from "fp-ts/ReadonlyArray";
+import { flow } from "fp-ts/function";
+
+export const mapDefinitionsByName = (name: string) => flow(
+	ReadonlyRecord.toEntries,
+	ReadonlyArray.map(([key, value]) => [key.slice(0, name.length), value] as const),
+	ReadonlyRecord.fromEntries,
+);
+
+export const definitionSource = (definition?: { contents: { segment: string }[] }) => 
+	definition ? definition.contents.map(({ segment }) => segment).join('') : null;

--- a/src/state/extension.ts
+++ b/src/state/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
-import { Actor, assign, createMachine } from "xstate";
+import { assign, createMachine } from "xstate";
 import { createApiClient } from "../api";
+import * as Commands from "../commands";
 import { CodebaseProvider } from "../tree-view";
 
 export interface Context {
@@ -173,8 +174,13 @@ export const createExtensionMachine = ({
 						treeDataProvider: codebaseProvider,
 					});
 
+					const editCommand = vscode.commands.registerCommand(
+						"unison-ui.edit",
+						Commands.edit(apiClient)
+					);
+
 					return {
-						subscriptions: [...ctx.subscriptions, treeView],
+						subscriptions: [...ctx.subscriptions, treeView, editCommand],
 						codebaseProvider,
 					};
 				}),


### PR DESCRIPTION
due to the nature of projectional editing, i think there are a lot of really cool possibilities to extend this extension with.

so i started with something that makes it more interactive, while keeping people in the normal Unison development loop.

even this simple feature could be improved in a few ways, but i thought i'd open it up for discussion before chasing that.

some of my thoughts & explanations are inline.