### PR TITLE
ask for project and branch

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -148,6 +148,12 @@ export function createApiProjectsClient(apiRoot: string): ApiProjectsClient {
 			const res = await fetch(url);
 			return unwrapResult(BranchNames.decode(await res.json())).map(v => v.branchName);
 		},
+		ucmCurrent: async () => {
+			const url = new URL(`${apiRoot}/ucm/current`);
+			const res = await fetch(url);
+			const v = unwrapResult(UcmCurrent.decode(await res.json()));
+			return [v.project, v.branch]
+		},
 	};
 }
 
@@ -156,6 +162,7 @@ export interface ApiProjectsClient {
 	branches: (
 		project: string
 	) => Promise<readonly string[]>;
+	ucmCurrent: () => Promise<[string, string]>;
 }
 
 const ProjectName = t.type(
@@ -179,3 +186,12 @@ export type TBranchName = t.TypeOf<typeof BranchName>;
 
 const BranchNames = t.array(BranchName);
 export type TBranchNames = t.TypeOf<typeof BranchNames>;
+
+const UcmCurrent = t.type(
+	{
+		project: t.string,
+		branch: t.string,
+	},
+	"UcmCurrent"
+);
+export type TUcmCurrent = t.TypeOf<typeof UcmCurrent>;

--- a/src/api.ts
+++ b/src/api.ts
@@ -135,3 +135,47 @@ export function createApiClient(apiRoot: string): ApiClient {
 		},
 	};
 }
+
+export function createApiProjectsClient(apiRoot: string): ApiProjectsClient {
+	return {
+		projects: async () => {
+			const url = new URL(`${apiRoot}/projects`);
+			const res = await fetch(url);
+			return unwrapResult(ProjectNames.decode(await res.json())).map(v => v.projectName);
+		},
+		branches: async (project) => {
+			const url = new URL(`${apiRoot}/projects/${project}/branches`);
+			const res = await fetch(url);
+			return unwrapResult(BranchNames.decode(await res.json())).map(v => v.branchName);
+		},
+	};
+}
+
+export interface ApiProjectsClient {
+	projects: () => Promise<readonly string[]>;
+	branches: (
+		project: string
+	) => Promise<readonly string[]>;
+}
+
+const ProjectName = t.type(
+	{
+		projectName: t.string,
+	},
+	"ProjectName"
+);
+export type TProjectName = t.TypeOf<typeof ProjectName>;
+
+const ProjectNames = t.array(ProjectName);
+export type TProjectNames = t.TypeOf<typeof ProjectNames>;
+
+const BranchName = t.type(
+	{
+		branchName: t.string,
+	},
+	"BranchName"
+);
+export type TBranchName = t.TypeOf<typeof BranchName>;
+
+const BranchNames = t.array(BranchName);
+export type TBranchNames = t.TypeOf<typeof BranchNames>;

--- a/src/state/extension.ts
+++ b/src/state/extension.ts
@@ -148,7 +148,10 @@ export const createExtensionMachine = ({
 							const apiClient = createApiProjectsClient(url);
 							return apiClient.projects()
 								.then(projects => {
-									return vscode.window.showQuickPick(projects, { title: "Pick project" });
+									return vscode.window.showQuickPick(projects, {
+										title: "Pick project",
+										placeHolder: "Choose project, or cancel for current project and branch in UCM."
+									});
 								}).then(project => {
 									if (project) {
 										return apiClient.branches(project).then(branches => [project, branches]);
@@ -156,8 +159,16 @@ export const createExtensionMachine = ({
 								}).then(v => {
 									const [project, branches] = v ?? [];
 									if (branches) {
-										return vscode.window.showQuickPick(branches as string[], { title: "Pick branch" }).then(branch => [project, branch]);
+										return vscode.window.showQuickPick(branches as string[], {
+											title: "Pick branch",
+											placeHolder: "Choose branch, or cancel for current project and branch in UCM."
+										}).then(branch => [project, branch]);
 									}
+								}).then(v => {
+									if (!v) {
+										return apiClient.ucmCurrent();
+									}
+									return v;
 								}).then(v => {
 									const [project, branch] = v ?? [];
 									if (branch) {


### PR DESCRIPTION
Simpler experience for users setting up the URL to Unison.

After providing the API url, via copy&paste from `ucm api`, the user will be asked to pick from available projects and branches.